### PR TITLE
Access GDBM via the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ And then execute:
 
     $ bundle
 
+## Dependencies
+
+You'll need to install the development libraries of the [GNU Database Library][gdbm]
+to use RIMS.
+
+[gdbm]: http://www.gnu.org.ua/software/gdbm/
+
 ## Simple Usage
 
 Type following to show usage.

--- a/rims.gemspec
+++ b/rims.gemspec
@@ -21,6 +21,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
+  spec.add_runtime_dependency 'ffi'
+  spec.add_runtime_dependency 'gdbm'
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
- Make the GDBM dependency explicit,
- Use the 'gdbm' gem,
- The advantage of using the gem is that it does not require
  recompilation of Ruby after the libgdbm development libraries
  are installed.
