### PR TITLE
Ensure Time objects have the correct timezone

### DIFF
--- a/test/test_protocol_decoder.rb
+++ b/test/test_protocol_decoder.rb
@@ -374,13 +374,13 @@ module RIMS::Test
 
     def add_mail_simple
       make_mail_simple
-      add_msg(@simple_mail.raw_source, Time.parse('2013-11-08 06:47:50 +0900'))
+      add_msg(@simple_mail.raw_source, Time.new(2013, 11, 8, 6, 47, 50, '+09:00'))
     end
     private :add_mail_simple
 
     def add_mail_multipart
       make_mail_multipart
-      add_msg(@mpart_mail.raw_source, Time.parse('2013-11-08 19:31:03 +0900'))
+      add_msg(@mpart_mail.raw_source, Time.new(2013, 11, 8, 19, 31, 3, '+09:00'))
     end
     private :add_mail_multipart
 

--- a/test/test_protocol_fetch.rb
+++ b/test/test_protocol_fetch.rb
@@ -73,19 +73,19 @@ module RIMS::Test
 
     def add_mail_simple
       make_mail_simple
-      @mail_store.add_msg(@inbox_id, @simple_mail.raw_source, Time.parse('2013-11-08 06:47:50 +0900'))
+      @mail_store.add_msg(@inbox_id, @simple_mail.raw_source, Time.new(2013, 11, 8, 6, 47, 50, '+09:00'))
     end
     private :add_mail_simple
 
     def add_mail_multipart
       make_mail_multipart
-      @mail_store.add_msg(@inbox_id, @mpart_mail.raw_source, Time.parse('2013-11-08 19:31:03 +0900'))
+      @mail_store.add_msg(@inbox_id, @mpart_mail.raw_source, Time.new(2013, 11, 8, 19, 31, 03, '+09:00'))
     end
     private :add_mail_multipart
 
     def add_mail_mime_subject
       make_mail_mime_subject
-      @mail_store.add_msg(@inbox_id, @mime_subject_mail.raw_source, Time.parse('2013-11-08 19:31:03 +0900'))
+      @mail_store.add_msg(@inbox_id, @mime_subject_mail.raw_source, Time.new(2013, 11, 8, 19, 31, 03, '+09:00'))
     end
     private :add_mail_mime_subject
 


### PR DESCRIPTION
- the use of Time.parse in the tests means that the Time objects
  obtained have the same timezone as the local system,
- the tests assume that the timezone in +0900 (JST),
- this change forces the Time objects to have +0900.
